### PR TITLE
Add a play-pause button for auto audio

### DIFF
--- a/halloween/index.html
+++ b/halloween/index.html
@@ -32,9 +32,20 @@
         <div id="content-wrap">
 
   <div class="showcase">
-    <div class="page about-page halloween-page">
+    <style>
+  button#scaryNight {
+    background-color: white;
+    border: 1px solid black;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 1.2em;
+    padding: 0.25em 0.5em;
+  }
+</style>
+<div class="page about-page halloween-page">
   <section class="info center">
-    <audio autoplay loop preload
+    <button id="scaryNight"><span>Play</span> ⏯️</button>
+    <audio loop preload
       src="/assets/scary_night.mp3">
       Your browser does not support the native <code>audio</code> playback.
     </audio>
@@ -44,6 +55,22 @@
   </section>
 
 </div>
+<script>
+  const button = document.querySelector("button#scaryNight");
+  const buttonText = document.querySelector("button#scaryNight > span");
+  const audio = document.querySelector("audio");
+
+  button.addEventListener("click", () => {
+    if (audio.paused) {
+      audio.volume = 0.5;
+      audio.play();
+      buttonText.innerHTML = "Pause";
+    } else {
+      audio.pause();
+      buttonText.innerHTML = "Play";
+    }
+  });
+</script>
 
   </div>
       </div> <!-- ends content-wrap -->


### PR DESCRIPTION
The browser policies don't allow autoplay for background audio.
Some interactions are needed to trigger the playback which must be listened to. 
Or a separate control that plays/pauses the audio. I have applied the latter.